### PR TITLE
Styling

### DIFF
--- a/webclient/src/components/home/CategoriesHighlights.js
+++ b/webclient/src/components/home/CategoriesHighlights.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import 'css/image.css';
+import './categories-highlights.css';
 
 const CategoriesHighlights = props => {
   const { categories } = props;
@@ -8,7 +9,10 @@ const CategoriesHighlights = props => {
     categories.length > 0 ? (
       categories.map((category, index) => {
         return (
-          <div className="col s6 l4 card z-depth-0 grey lighten-4" key={index}>
+          <div
+            className="col s12 m6 l4 card z-depth-0 grey lighten-4"
+            key={index}
+          >
             <div
               className="card-image waves-effect waves-block waves-light"
               style={{ borderRadius: 5, boxShadow: '1px 3px 10px #aaa' }}

--- a/webclient/src/components/home/categories-highlights.css
+++ b/webclient/src/components/home/categories-highlights.css
@@ -1,0 +1,12 @@
+.card .card-image .card-title {
+  background: rgba(0, 0, 0, 0.3);
+  width: 100%;
+}
+
+@media only screen and (max-width: 600px) {
+  .card .card-image .card-title {
+    padding: 15px;
+    font-size: 16px;
+    margin: auto;
+  }
+}

--- a/webclient/src/components/layout/Footer.js
+++ b/webclient/src/components/layout/Footer.js
@@ -4,16 +4,16 @@ import Logo from '../../assets/images/logo.png';
 
 const Footer = props => {
   return (
-    <>
-      <footer className="footer">
+    <footer className="footer">
+      <div className="container">
         <div className="footer__logo">
           <img
             src={Logo}
             alt="Logo"
-            style={{ height: 100, marginTop: 10, marginBottom: -10 }}
+            style={{ height: 75, marginTop: 5, marginBottom: -25 }}
           />
           <h3>VISIT</h3>
-          <h5>Perhimpunan Indonesia NUS</h5>
+          <h6>Perhimpunan Indonesia NUS</h6>
         </div>
         <div className="footer__links">
           <ul className="footer__col">
@@ -81,11 +81,13 @@ const Footer = props => {
             </li>
           </ul>
         </div>
-        <div className="ending">
-          Copyright @2020 PINUS. All rights reserved.
-        </div>
-      </footer>
-    </>
+      </div>
+      <div className="spacer" />
+      <div className="spacer" />
+      <div className="ending">
+        &copy; 2020 - Present Perhimpunan Indonesia NUS. All rights reserved
+      </div>
+    </footer>
   );
 };
 

--- a/webclient/src/components/layout/Navbar.js
+++ b/webclient/src/components/layout/Navbar.js
@@ -43,6 +43,7 @@ const Navbar = props => {
   return (
     <>
       <ul id="nav-mobile" className="sidenav">
+        <li style={{ height: 20 }}></li>
         <li>
           <a id="logo-container" href="#landing">
             <img
@@ -52,6 +53,7 @@ const Navbar = props => {
             />
           </a>
         </li>
+        <li style={{ height: 20 }}></li>
         <li>
           <a target="_blank" href="https:pi-nus.org">
             PINUS Homepage
@@ -77,7 +79,10 @@ const Navbar = props => {
             </li>
           </>
         ) : (
-          <li> <NavLink to="/login"> Login </NavLink> </li>
+          <li>
+            {' '}
+            <NavLink to="/login"> Login </NavLink>{' '}
+          </li>
         )}
       </ul>
 
@@ -85,17 +90,21 @@ const Navbar = props => {
         <a href="#" data-target="nav-mobile" className="sidenav-trigger">
           <i className="fas fa-bars"></i>
         </a>
-        <img
-          src={Logo}
-          className="hide-on-large-only"
-          alt="PINUS Logo"
-          style={{
-            height: 40,
-            marginTop: 8,
-            position: 'absolute',
-            left: 'calc(50% - 70px)'
-          }}
-        />
+        <Link to="/" className="brand-logo hide-on-large-only">
+          <span style={{ textTransform: 'uppercase' }}>
+            <img
+              src={Logo}
+              alt="PINUS Logo"
+              style={{
+                height: 40,
+                verticalAlign: 'middle',
+                paddingRight: 10,
+                transform: 'translateY(-5px)'
+              }}
+            />
+            Visit
+          </span>
+        </Link>
 
         <ul id="dropdownLogout" className="dropdown-content">
           <li>
@@ -115,7 +124,19 @@ const Navbar = props => {
 
         <div className="container hide-on-med-and-down">
           <Link to="/" className="brand-logo">
-            Visintus
+            <span style={{ textTransform: 'uppercase' }}>
+              <img
+                src={Logo}
+                alt="PINUS Logo"
+                style={{
+                  height: 40,
+                  verticalAlign: 'middle',
+                  paddingRight: 10,
+                  transform: 'translateY(-5px)'
+                }}
+              />
+              Visit
+            </span>
           </Link>
           <ul className="right">
             <li>
@@ -141,7 +162,10 @@ const Navbar = props => {
                 </a>
               </li>
             ) : (
-              <li> <NavLink to="/login">Login</NavLink> </li>
+              <li>
+                {' '}
+                <NavLink to="/login">Login</NavLink>{' '}
+              </li>
             )}
           </ul>
         </div>

--- a/webclient/src/components/layout/Navbar.js
+++ b/webclient/src/components/layout/Navbar.js
@@ -45,13 +45,13 @@ const Navbar = props => {
       <ul id="nav-mobile" className="sidenav">
         <li style={{ height: 20 }}></li>
         <li>
-          <a id="logo-container" href="#landing">
+          <Link to="/" id="logo-container">
             <img
               src={Logo}
               alt="PINUS Logo"
               style={{ height: 50, marginTop: 5 }}
             />
-          </a>
+          </Link>
         </li>
         <li style={{ height: 20 }}></li>
         <li>
@@ -62,7 +62,7 @@ const Navbar = props => {
         <li>
           <NavLink to="/itinerary">Itinerary</NavLink>
         </li>
-        {isLoggedIn === 'true' ? (
+        {/* {isLoggedIn === 'true' ? (
           <>
             <li>
               <NavLink to="/">Account</NavLink>
@@ -83,7 +83,7 @@ const Navbar = props => {
             {' '}
             <NavLink to="/login"> Login </NavLink>{' '}
           </li>
-        )}
+        )} */}
       </ul>
 
       <nav className="nav-wrapper black ">
@@ -147,7 +147,7 @@ const Navbar = props => {
             <li>
               <NavLink to="/itinerary">Itinerary</NavLink>
             </li>
-            {isLoggedIn === 'true' ? (
+            {/* {isLoggedIn === 'true' ? (
               <li>
                 <a
                   className="dropdown-trigger"
@@ -166,7 +166,7 @@ const Navbar = props => {
                 {' '}
                 <NavLink to="/login">Login</NavLink>{' '}
               </li>
-            )}
+            )} */}
           </ul>
         </div>
       </nav>

--- a/webclient/src/css/area.css
+++ b/webclient/src/css/area.css
@@ -9,11 +9,9 @@
 }
 
 .people .team {
-  margin: 0 10px 20px;
+  margin: 0 auto 20px;
   position: relative;
   width: 100%;
-  min-height: 250px;
-  float: left;
   background: #fff;
   box-sizing: border-box;
   overflow: hidden;
@@ -22,9 +20,10 @@
 .people .team img {
   width: 100%;
   transition: 0.7s;
+  object-fit: cover;
 }
 .people .team:hover img {
-  transform: scale(1.15);
+  transform: scale(1.1);
 }
 .people .team .details {
   position: absolute;

--- a/webclient/src/css/footer.css
+++ b/webclient/src/css/footer.css
@@ -66,6 +66,10 @@
   padding: 1em;
 }
 
+.spacer {
+  height: 20px;
+}
+
 @media only screen and (max-width: 600px) {
   .footer__links {
     display: block;

--- a/webclient/src/index.css
+++ b/webclient/src/index.css
@@ -1,8 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Lexend Deca', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
Short Writeup 21-04
Bugs killed: 
- center logo in mobile
- cards in homepage now only 1 column in mobile
- add dark backdrop to compensate white text for cards in homepage 
- revamp footer look -> spacing, font size, lineheight etc.
- Fix logo spacing in sidenav

Features added:
- Add logo besides 'VISIT' in desktop page
- Add 'VISIT' besides logo in mobile
- Change font to match pinus homepage (pi-nus.org)
- Add links to homepage on all logo or 'VISIT' text


NOTE: as of this update, login must be accessed manually through browser url